### PR TITLE
Allow typeDefs to be string | DocumentNode

### DIFF
--- a/src/GraphQLGenieInterfaces.ts
+++ b/src/GraphQLGenieInterfaces.ts
@@ -1,4 +1,4 @@
-import { GraphQLFieldResolver } from 'graphql';
+import { DocumentNode, GraphQLFieldResolver } from 'graphql';
 import { GraphQLGenie } from '.';
 import { GraphQLSchemaBuilder } from './GraphQLSchemaBuilder';
 export interface TypeGenerator {
@@ -72,7 +72,7 @@ export interface GenerateConfig {
 
 export interface GraphQLGenieOptions {
 	schemaBuilder?: GraphQLSchemaBuilder;
-	typeDefs?: string;
+	typeDefs?: string | DocumentNode;
 	generatorOptions?: GenerateConfig;
 	fortuneOptions?: FortuneOptions;
 }

--- a/src/GraphQLSchemaBuilder.ts
+++ b/src/GraphQLSchemaBuilder.ts
@@ -1,5 +1,5 @@
 
-import { GraphQLFieldResolver, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLType, getNamedType, isInputObjectType, isInputType, isInterfaceType, isListType, isNonNullType, isObjectType, isScalarType, isSpecifiedDirective, isUnionType, print } from 'graphql';
+import { DocumentNode, GraphQLFieldResolver, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLType, getNamedType, isInputObjectType, isInputType, isInterfaceType, isListType, isNonNullType, isObjectType, isScalarType, isSpecifiedDirective, isUnionType, print  } from 'graphql';
 import { GraphQLDate, GraphQLDateTime, GraphQLTime } from 'graphql-iso-date';
 import { IResolvers, SchemaDirectiveVisitor, addResolveFunctionsToSchema, makeExecutableSchema } from 'graphql-tools';
 import GraphQLJSON from 'graphql-type-json';
@@ -15,7 +15,7 @@ export class GraphQLSchemaBuilder {
 	private typeDefs: string;
 	private config: GenerateConfig;
 	private resolveFunctions: IResolvers<any, any>;
-	constructor(typeDefs = '', $config: GenerateConfig) {
+	constructor(typeDefs: string | DocumentNode = '', $config: GenerateConfig) {
 		this.typeDefs = `
 		scalar JSON
 		scalar Date
@@ -45,7 +45,7 @@ export class GraphQLSchemaBuilder {
 			"""
 			id: ID! @unique
 		}
-		` + typeDefs;
+		` + (typeof typeDefs === 'string' ? typeDefs : print(typeDefs));
 		this.resolveFunctions = {
 			JSON: GraphQLJSON,
 			Date: GraphQLDate,


### PR DESCRIPTION
This allows syntax highlighting and formatting in editors using `graphql-tag`.

![screen shot 2018-08-07 at 12 46 16 pm](https://user-images.githubusercontent.com/5205440/43798634-0d821276-9a40-11e8-91db-7def3f23ee1c.png)



See https://github.com/apollographql/graphql-tag/issues/144 for discussion about stringifying document nodes.