### PR TITLE
Make genie.init() more synchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "tslint -c tslint.json -p tsconfig.json --fix"
   },
   "jest": {
+    "testURL": "http://localhost",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/SchemaInfoBuilder.ts
+++ b/src/SchemaInfoBuilder.ts
@@ -1,4 +1,4 @@
-import { GraphQLError, GraphQLSchema, IntrospectionType, getIntrospectionQuery, graphql } from 'graphql';
+import { GraphQLSchema, IntrospectionType, introspectionFromSchema } from 'graphql';
 import { concat, each, findIndex, get, includes, keys, mapKeys, omit, omitBy, set, startsWith } from 'lodash';
 
 export default class SchemaInfoBuilder {
@@ -10,9 +10,9 @@ export default class SchemaInfoBuilder {
 		this.schema = schema;
 	}
 
-	public async getSchemaInfo(): Promise<IntrospectionType[]> {
+	public getSchemaInfo(): IntrospectionType[] {
 		if (!this.schemaInfo) {
-			this.schemaInfo = await this.buildSchemaInfo(this.schema);
+			this.schemaInfo = this.buildSchemaInfo(this.schema);
 		}
 		return this.schemaInfo;
 	}
@@ -29,12 +29,8 @@ export default class SchemaInfoBuilder {
 		set(schemaInfo, path, directives);
 	}
 
-	private async buildSchemaInfo(schema): Promise<IntrospectionType[]>  {
-		let originalSchemaInfo = await graphql(schema, getIntrospectionQuery({ descriptions: true }));
-		if (originalSchemaInfo.errors) {
-			throw new GraphQLError(originalSchemaInfo.errors[0].message);
-		}
-		originalSchemaInfo = originalSchemaInfo.data;
+	private buildSchemaInfo(schema): IntrospectionType[]  {
+		const originalSchemaInfo = introspectionFromSchema(schema, {descriptions: true});
 		let schemaInfo = <any>originalSchemaInfo;
 		schemaInfo = omitBy(schemaInfo.__schema.types, (value) => {
 			return startsWith(value.name, '__') || includes(['Boolean', 'String', 'ID', 'Int', 'Float'], value.name);


### PR DESCRIPTION
Thanks so much for this amazing project! I think it has tons of potential!

In using `graphql-genie` I've found it annoying that `genie.init()` returns a promise (especially in aws lambda as I've needed to wrap the handler function.)

```typescript
// current
const genie = new GraphQLGenie({ typeDefs, fortuneOptions });

export const handler: APIGatewayProxyHandler = (event, context, cb) => {
    genie.init().then(() => {
        const schema: GraphQLSchema = genie.getSchema();
        const server = new ApolloServer({ schema });
        server.createHandler()(event, context, cb);
    });
};
```

```typescript
// with synchronous init
const genie = new GraphQLGenie({ typeDefs, fortuneOptions });
genie.init(); // synchronous
const schema = genie.getSchema();
const server = new ApolloServer({ schema });

export const handler: APIGatewayProxyHandler = server.createHandler();
```

The only async things happening within the `init()` function were calls to the introspection query using `graphql(schema, query)` which can be done synchronously using `introspectionFromSchema` from `graphql`

This PR removes those internal async calls but leaves `init()` as async because it looks like some plugins may return promises. If it is possible to require plugins to run synchronously then this can be removed and `init()` can be entirely synchronous.

```typescript
await Promise.all(this.plugins.map(async (plugin) => {
	const pluginResult = plugin(this);
	if (pluginResult.then) {
		await pluginResult;
	}
}));